### PR TITLE
Item info refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+
+.vs
+*.wowproj
+*.wowsln

--- a/Events.lua
+++ b/Events.lua
@@ -223,6 +223,7 @@ local function OnWhisperReceived(msg, author, language, status, msgid, unknown, 
 end
 
 local function OnItemInfoRecieved(itemId, success)
+    LootRaffle.Log("OnItemInfoRecieved("..itemId..", "..tostring(success).. ")")
     local name, itemLink = GetItemInfo(itemId)
     if not itemLink then return end
     local deadLink = LootRaffle_GetItemNameFromLink(itemLink)

--- a/Events.lua
+++ b/Events.lua
@@ -96,12 +96,16 @@ function SlashCmdList.LootRaffle(msg, editbox)
         if not name then
             print("LootRaffle commands:"); 
             print(" - '[Item Link]': Starts a raffle");
-            print(" - 'logging (on|off)': Toggles logging");
-            print(" - 'auto-detect (on|off)': Toggles Automatic raffle prompt when you loot a tradable item.");
-            print(" - 'ignore [Item Link]': Adds [Item Link] to your ignore list. Ignored items won't prompt you to start a raffle.");
-            print(" - 'unignore [Item Link]': Removes [Item Link] from your ignore list.");
-            print(" - 'showignore': Prints out your ignore list.");
-            print(" - 'clearignore': Clears the ignore list.");
+            print(" - 'auto-detect (on|off)': Toggles Automatic raffle prompt when you loot a tradable item");
+            print(" - 'ignore [Item Link]': Adds [Item Link] to your ignore list. Ignored items won't prompt you to start a raffle");
+            print(" - 'unignore [Item Link]': Removes [Item Link] from your ignore list");
+            print(" - 'showignore': Prints out your ignore list");
+            print(" - 'clearignore': Clears the ignore list");
+            print("LootRaffle debug commands:"); 
+            print(" - 'logging (on|off)': Toggles debug logging");
+            print(" - '[Item Link] tradable': Returns if LootRaffle thinks the item is tradable");
+            print(" - '[Item Link] usable (optional: unit name)': Returns if LootRaffle thinks the item is usable by the unit. Defaults to 'player' unit");
+            print(" - '[Item Link] prompt': Triggers the raffle prompt window for the linked item");
             return
         end
 

--- a/Events.lua
+++ b/Events.lua
@@ -53,7 +53,7 @@ function SlashCmdList.LootRaffle(msg, editbox)
     elseif string.find(msg, "showignore") then
         print("[LootRaffle] Showing ignore list...")
         LootRaffle_ShowIgnored()
-    elseif string.find(msg, "test") then
+    elseif string.find(msg, "test-roll") then
         local itemLink = select(2, GetItemInfo(msg)) or GetContainerItemLink(0, 1)
         print("[LootRaffle] Testing item: "..itemLink)
         if itemLink then
@@ -94,18 +94,35 @@ function SlashCmdList.LootRaffle(msg, editbox)
         -- try for item
         local name, itemLink, quality, itemLevel, requiredLevel, class, subClass, maxStack, equipSlot, texture, vendorPrice = GetItemInfo(msg)
         if not name then
-            print("LootRaffle commands:"); 
-            print(" - '[Item Link]': Starts a raffle");
-            print(" - 'auto-detect (on|off)': Toggles Automatic raffle prompt when you loot a tradable item");
-            print(" - 'ignore [Item Link]': Adds [Item Link] to your ignore list. Ignored items won't prompt you to start a raffle");
-            print(" - 'unignore [Item Link]': Removes [Item Link] from your ignore list");
-            print(" - 'showignore': Prints out your ignore list");
-            print(" - 'clearignore': Clears the ignore list");
-            print("LootRaffle debug commands:"); 
-            print(" - 'logging (on|off)': Toggles debug logging");
-            print(" - '[Item Link] tradable': Returns if LootRaffle thinks the item is tradable");
-            print(" - '[Item Link] usable (optional: unit name)': Returns if LootRaffle thinks the item is usable by the unit. Defaults to 'player' unit");
-            print(" - '[Item Link] prompt': Triggers the raffle prompt window for the linked item");
+            print([[
+
+-- LootRaffle Commands --
+/raffle [Item Link]
+    Starts a raffle
+/raffle auto-detect (on|off)
+    Toggles Automatic raffle prompt when you loot a tradable item
+/raffle ignore [Item Link]
+    Adds [Item Link] to your ignore list. Ignored items won't prompt you to start a raffle
+/raffle unignore [Item Link]
+    Removes [Item Link] from your ignore list
+/raffle showignore
+    Prints out your ignore list
+/raffle clearignore
+    Clears the ignore list
+
+-- LootRaffle Debug Commands --
+/raffle logging (on|off)
+    Toggles debug logging
+/raffle [Item Link] test-roll
+    Shows a test roll window for the item
+/raffle [Item Link] tradable
+    Returns if LootRaffle thinks the item is tradable
+/raffle [Item Link] usable (unit)
+    Returns if LootRaffle thinks the item is usable by the unit. Defaults to 'player' unit
+/raffle [Item Link] prompt
+    Triggers the raffle prompt window for the linked item
+
+]])
             return
         end
 

--- a/Events.lua
+++ b/Events.lua
@@ -8,7 +8,7 @@ function SlashCmdList.LootRaffle(msg, editbox)
     elseif msg == "hide" then
         -- LootRaffle_Frame:Hide();
     elseif string.find(msg, "^data") then
-        local itemLink = select(2, GetItemInfo(msg)) or GetContainerItemLink(0, 1)
+        local itemLink = select(2, GetItemInfo(msg)) or C_Container.GetContainerItemLink(0, 1)
         if itemLink then
             local tooltipData = LootRaffle_GetItemTooltipTableByItemLink(itemLink)
             print("--", itemLink, "--")
@@ -53,16 +53,22 @@ function SlashCmdList.LootRaffle(msg, editbox)
     elseif string.find(msg, "showignore") then
         print("[LootRaffle] Showing ignore list...")
         LootRaffle_ShowIgnored()
-    elseif string.find(msg, "test-roll") then
-        local itemLink = select(2, GetItemInfo(msg)) or GetContainerItemLink(0, 1)
-        print("[LootRaffle] Testing item: "..itemLink)
+    elseif string.find(msg, "loot") then
+        local itemLink = select(2, GetItemInfo(msg)) or C_Container.GetContainerItemLink(0, 1)
+        print("[LootRaffle] Testing pretend looting of: "..itemLink)
+        if itemLink then
+            LootRaffle_ProcessLootedItem("You received loot: "..itemLink)
+        end
+    elseif string.find(msg, "roll") then
+        local itemLink = select(2, GetItemInfo(msg)) or C_Container.GetContainerItemLink(0, 1)
+        print("[LootRaffle] Showing roll window for: "..itemLink)
         if itemLink then
             local bag, slot = LootRaffle_GetTradableItemBagPosition(itemLink)
             local playerName, playerRealmName = UnitFullName('player')
             LootRaffle_ShowRollWindow(itemLink, playerName, playerRealmName)
         end
     elseif string.find(msg, "tradable") then
-        local itemLink = select(2, GetItemInfo(msg)) or GetContainerItemLink(0, 1)
+        local itemLink = select(2, GetItemInfo(msg)) or C_Container.GetContainerItemLink(0, 1)
         print("[LootRaffle] Testing if item: "..itemLink.." is tradable.")
         if itemLink then
             local bag, slot = LootRaffle_GetTradableItemBagPosition(itemLink)
@@ -73,7 +79,7 @@ function SlashCmdList.LootRaffle(msg, editbox)
             end
         end
     elseif string.find(msg, "usable") then
-        local itemLink = select(2, GetItemInfo(msg)) or GetContainerItemLink(0, 1)
+        local itemLink = select(2, GetItemInfo(msg)) or C_Container.GetContainerItemLink(0, 1)
         local unitName = string.match(msg, "usable ([%a%d]+)")
         if not unitName then unitName = "player" end
         if not UnitClass(unitName) then
@@ -89,7 +95,7 @@ function SlashCmdList.LootRaffle(msg, editbox)
             end
         end
     elseif string.find(msg, "prompt") then
-        local itemLink = select(2, GetItemInfo(msg)) or GetContainerItemLink(0, 1)
+        local itemLink = select(2, GetItemInfo(msg)) or C_Container.GetContainerItemLink(0, 1)
         print("[LootRaffle] Testing prompt for item: "..itemLink)
         if itemLink then
             LootRaffle_PromptForRaffle(itemLink)
@@ -117,7 +123,9 @@ function SlashCmdList.LootRaffle(msg, editbox)
 -- LootRaffle Debug Commands --
 /raffle logging (on|off)
     Toggles debug logging
-/raffle [Item Link] test-roll
+/raffle [Item Link] loot
+    Simulates looting of the linked item
+/raffle [Item Link] roll
     Shows a test roll window for the item
 /raffle [Item Link] tradable
     Returns if LootRaffle thinks the item is tradable
@@ -236,7 +244,7 @@ local function OnWhisperReceived(msg, author, language, status, msgid, unknown, 
 end
 
 local function OnItemInfoRecieved(itemId, success)
-    LootRaffle.Log("OnItemInfoRecieved("..itemId..", "..tostring(success).. ")")
+    --LootRaffle.Log("OnItemInfoRecieved("..itemId..", "..tostring(success).. ")")
     local name, itemLink = GetItemInfo(itemId)
     if not itemLink then return end
     local deadLink = LootRaffle_GetItemNameFromLink(itemLink)

--- a/Events.lua
+++ b/Events.lua
@@ -163,7 +163,7 @@ local function OnMessageRecieved(prefix, message)
     if prefix == LootRaffle.NEW_RAFFLE_MESSAGE then
         local rafflerName, raffleId, itemLink = LootRaffle_Notification_ParseRaffleStart(message)
         if rafflerName == LootRaffle_UnitFullName("player") then return end
-        LootRaffle.Log("New raffle message recieved from: ", rafflerName, " for id:", raffleId, "item: ", itemLink)
+        LootRaffle.Log("New raffle message received from: ", rafflerName, " for id:", raffleId, "item: ", itemLink)
         local name = GetItemInfo(itemLink)
         if name then
             LootRaffle_HandleNewRaffleNotification(itemLink, rafflerName, raffleId)
@@ -176,7 +176,7 @@ local function OnMessageRecieved(prefix, message)
     elseif prefix == LootRaffle.ROLL_ON_ITEM_MESSAGE then
         local rafflerName, raffleId, itemLink, rollerName, rollType = LootRaffle_Notification_ParseRoll(message)
         if rafflerName ~= LootRaffle_UnitFullName("player") then return end
-        LootRaffle.Log("Roll message recieved from:", rollerName, rollType, "for:", itemLink)
+        LootRaffle.Log("Roll message received from:", rollerName, rollType, "for:", itemLink)
         LootRaffle_HandleRollNotification(raffleId, rollerName, rollType)
     end
 end

--- a/ItemFunctions.lua
+++ b/ItemFunctions.lua
@@ -1,8 +1,10 @@
 local _, LootRaffle_Local=...
 
-function LootRaffle_GetTradableItemBagPosition(itemLink)
-    LootRaffle.Log("Searching for", itemLink, "in bags...")
-    local variantFragmentPattern = LootRaffle_EscapePatternCharacters(select(1, GetItemInfo(itemLink))).." of "
+function LootRaffle_GetTradableItemBagPosition(itemLink, isFuzzy)
+    LootRaffle.Log("Searching for", itemLink, "(fuzzy: "..tostring(isFuzzy)..") in bags...")
+    local itemName = select(1, GetItemInfo(itemLink))
+    local fuzzyItemName = LootRaffle_EscapePatternCharacters("h["..itemName.."]")
+    local variantFragmentPattern = LootRaffle_EscapePatternCharacters(itemName.." of ")
     for bag = BACKPACK_CONTAINER, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
         --LootRaffle.Log("Searching bag", bag)
 	    for slot = 1,  C_Container.GetContainerNumSlots(bag) do
@@ -10,13 +12,14 @@ function LootRaffle_GetTradableItemBagPosition(itemLink)
             if containerItemLink then
                 local isNameMatch = false
 
-                containerItemLink = string.gsub(containerItemLink, "Player-[-%a%d]+", "") -- try removing crafter player id, ie: "Player-1190-0B8EB803" which doesn't appear in chat-linked item links
-                --LootRaffle.Log("Checking "..containerItemLink..":\n"..gsub(containerItemLink, "\124", "\124\124").."\nagainst\n"..gsub(itemLink, "\124", "\124\124").."\nfound in slot: "..bag..","..slot)
                 if containerItemLink == itemLink then
                     LootRaffle.Log(itemLink.." found in slot: "..bag..","..slot)
                     isNameMatch = true
                 elseif string.find(containerItemLink, variantFragmentPattern) then -- check for variant. "Bracers of Intellect", etc.
                     LootRaffle.Log("Green item variant for "..itemLink.." found in slot: "..bag..","..slot)
+                    isNameMatch = true
+                elseif isFuzzy and string.find(containerItemLink, fuzzyItemName) then
+                    LootRaffle.Log("Fuzzy match "..fuzzyItemName.." found in "..gsub(containerItemLink, "\124", "\124\124").." for "..itemLink.." in slot: "..bag..","..slot)
                     isNameMatch = true
                 end
 

--- a/ItemFunctions.lua
+++ b/ItemFunctions.lua
@@ -21,11 +21,11 @@ function LootRaffle_GetTradableItemBagPosition(itemLink)
                 end
 
                 if isNameMatch then
-			        local isTradeable = LootRaffle_IsTradableItem(containerItemLink, bag, slot)
-                    if isTradeable then
+			        local isTradable = LootRaffle_IsTradableItem(containerItemLink, bag, slot)
+                    if isTradable then
                         return bag, slot
                     else
-                        LootRaffle.Log("Slot", bag..","..slot, "is not tradeable")
+                        LootRaffle.Log("Slot", bag..","..slot, "is not tradable")
 			        end
                 else
                     LootRaffle.Log("Slot", bag..","..slot, "name did not match")
@@ -35,7 +35,7 @@ function LootRaffle_GetTradableItemBagPosition(itemLink)
 		    end
         end
     end
-    LootRaffle.Log(itemLink, "not found in bags or wasn't tradeable.")
+    LootRaffle.Log(itemLink, "not found in bags or wasn't tradable.")
 end
 
 function LootRaffle_IsTradableItem(itemLink, bag, slot)

--- a/ItemFunctions.lua
+++ b/ItemFunctions.lua
@@ -87,7 +87,7 @@ function LootRaffle_UnitCanUseItem(unitName, itemLink)
             end
         end
         if not found then
-            LootRaffle.Log("Player CANNOT use "..item.ItemClass.." of type "..item.ItemSubClass..". Wrong reilc type '"..item.RelicType.."' for class: "..classCodeName..".")
+            LootRaffle.Log("Player CANNOT use "..item.ItemClass.." of type "..item.ItemSubClass..". Wrong relic type '"..item.RelicType.."' for class: "..classCodeName..".")
             return false
         end
     end
@@ -161,7 +161,7 @@ function LootRaffle_CategorizeTooltipText(text, itemInfo)
     end
 
     --check if trading this BoP is still allowed
-    --splits the template string on the macro text (%s), checks to see if both halfs match
+    --splits the template string on the macro text (%s), checks to see if both halves match
     if not itemInfo.TemporarilyTradable then
         local pattern = LootRaffle_EscapePatternCharacters(BIND_TRADE_TIME_REMAINING) -- "You may trade this item with players that were also eligible to loot this item for the next %s."
         pattern = string.gsub(pattern, "%%%%s", ".+")

--- a/ItemFunctions.lua
+++ b/ItemFunctions.lua
@@ -217,16 +217,19 @@ function LootRaffle_GetItemTooltipTableByBagSlot(bag, slot)
     itemTooltip:SetBagItem(bag, slot)
     return LootRaffle_GetItemTooltipTable(itemTooltip)
 end
+
 function LootRaffle_GetItemTooltipTableByItemLink(itemLink)
     local itemTooltip = LootRaffle_BuildItemTooltip()
     itemTooltip:SetHyperlink(itemLink)
     return LootRaffle_GetItemTooltipTable(itemTooltip)
 end
+
 function LootRaffle_BuildItemTooltip()
     local itemTooltip = CreateFrame("GameTooltip", "LootRaffle_ParseItemTooltip", nil, "GameTooltipTemplate")
     itemTooltip:SetOwner(UIParent, "ANCHOR_NONE")
     return itemTooltip
 end
+
 function LootRaffle_GetItemTooltipTable(itemTooltip)
     local tooltipTable = {}
     itemTooltip:Show()

--- a/ItemFunctions.lua
+++ b/ItemFunctions.lua
@@ -4,7 +4,7 @@ function LootRaffle_GetTradableItemBagPosition(itemLink)
     LootRaffle.Log("Searching for", itemLink, "in bags...")
     local variantFragmentPattern = LootRaffle_EscapePatternCharacters(select(1, GetItemInfo(itemLink))).." of "
     for bag = BACKPACK_CONTAINER, NUM_TOTAL_EQUIPPED_BAG_SLOTS do
-        LootRaffle.Log("Searching bag", bag)
+        --LootRaffle.Log("Searching bag", bag)
 	    for slot = 1,  C_Container.GetContainerNumSlots(bag) do
             local containerItemLink = C_Container.GetContainerItemLink(bag, slot)
             if containerItemLink then
@@ -25,17 +25,17 @@ function LootRaffle_GetTradableItemBagPosition(itemLink)
                     if isTradable then
                         return bag, slot
                     else
-                        LootRaffle.Log("Slot", bag..","..slot, "is not tradable")
+                        LootRaffle.Log("Slot", bag..","..slot, "matched but is not tradable")
 			        end
                 else
-                    LootRaffle.Log("Slot", bag..","..slot, "name did not match")
+                    --LootRaffle.Log("Slot", bag..","..slot, "name did not match")
 				end
             else
-                LootRaffle.Log("Slot", bag..","..slot, "contains no item")
+                --LootRaffle.Log("Slot", bag..","..slot, "contains no item")
 		    end
         end
     end
-    LootRaffle.Log(itemLink, "not found in bags or wasn't tradable.")
+    LootRaffle.Log(itemLink, "no tradable match was found in bags")
 end
 
 function LootRaffle_IsTradableItem(itemLink, bag, slot)

--- a/LootRaffle.toc
+++ b/LootRaffle.toc
@@ -1,7 +1,7 @@
 ## Interface: 100002
 ## Title: LootRaffle
 ## Author: Taunkah - Doomhammer
-## Version: 1.2.8
+## Version: 1.2.10
 ## Notes: Easily share loot with your party or raid.
 ## SavedVariables: LootRaffle_DB
 

--- a/Raffler.lua
+++ b/Raffler.lua
@@ -3,7 +3,7 @@ local _, LootRaffle_Local=...
 function LootRaffle_ProcessLootedItem(itemParam, attempt)
     -- attempt to find the item info and slot info of each looted item
     attempt = (attempt or 0) + 1
-    if attempt > 10 then --max retries to find the item data
+    if attempt > LootRaffle.MaxItemSearchAttempts then --max retries to find the item data
         LootRaffle.Log("Max loot processing retries for item:", "\""..itemParam.."\"")
         return
     end

--- a/Raffler.lua
+++ b/Raffler.lua
@@ -59,7 +59,7 @@ end
 function LootRaffle_TryPromptForRaffle(itemLink)
     if itemLink then
         if LootRaffle.PossibleRafflePromptShown then
-            LootRaffle.Log("Prompt already shown. Queueing "..itemLink.."...")
+            LootRaffle.Log("Prompt already shown. Queuing "..itemLink.."...")
             table.insert(LootRaffle.PossibleRaffleItems, itemLink)
             LootRaffle.PossibleRaffleItemCount = LootRaffle.PossibleRaffleItemCount + 1
         else

--- a/Raffler.lua
+++ b/Raffler.lua
@@ -22,7 +22,13 @@ function LootRaffle_ProcessLootedItem(itemParam, attempt)
         return
     end
 
-    local bag, slot = LootRaffle_GetTradableItemBagPosition(itemLink)
+    local isFuzzySearch = false
+    if attempt == LootRaffle.MaxItemSearchAttempts then --last-ditch effort to find item in bags by using fuzzy match
+        LootRaffle.Log("Attempting final loot process with fuzzy search for item:", "\""..itemParam.."\"")
+        isFuzzySearch = true
+    end
+
+    local bag, slot = LootRaffle_GetTradableItemBagPosition(itemLink, isFuzzySearch)
     if not bag or not slot then
         LootRaffle.Log("Bag and slot not yet available for:", itemLink)
         LootRaffle_WaitToProcessLootedItem(itemParam, attempt)

--- a/State.lua
+++ b/State.lua
@@ -28,5 +28,6 @@ LootRaffle = {
     PlayerAcceptedTrade = false,
     IgnoredItems = {},
     ItemInfoCache = {},
-    ItemRequests = {}
+    ItemRequests = {},
+    MaxItemSearchAttempts = 5
 }


### PR DESCRIPTION
## The Good

This PR introduces changes that should improve the efficiency of how the addon examines loot by using new APIs available from blizzard. It does this by using the new `C_TooltipInfo.GetBagItem` and `C_TooltipInfo.GetHyperlink` functions available in the WoW API to get the item information as opposed to building a fake tooltip and parsing the frame text.

### Other Improvements

- Items are more often correctly found in bags (since the last expansion)
- Cleaner `/raffle help` print out
- More debug commands/options for testing the addon
- More efficient execution
- Better log messages for debugging

## The Bad

Unfortunately, searching for bag items by item link is no longer a reliable way to detect new raffle opportunities. The loot message item link is no longer guaranteed to be the same as the item link found in the bag slots. A fuzzy-search was introduced, which has a small chance to create a false-positive by offering to let you raffle something that isn't the exact item that you intended.

If anyone at Blizzard happens to read this, we need an API event that provides the bag index AND slot index (and, ideally, quantity) for any item(s) that enter the bag from an outside source (loot, craft, interact, etc.). That would drastically reduce the code and CPU required for this addon to work properly and improve its accuracy.